### PR TITLE
Fix .gitattributes extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,2 @@
 # GameMaker Files
 *.yy linguist-language=Game Maker Language
-*.yyp linguist-language=Game Maker Language
-*.resource_order linguist-language=Game Maker Language

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# GameMaker Files
+*.yy linguist-language=Game Maker Language
+*.yyp linguist-language=Game Maker Language
+*.resource_order linguist-language=Game Maker Language

--- a/.gitattributes.txt
+++ b/.gitattributes.txt
@@ -1,1 +1,0 @@
-*.yy linguist-language=Game Maker Language


### PR DESCRIPTION
Renamed `.gitattributes` to correctly display language stats.